### PR TITLE
fix tests to pass regression caused by changes in vegan

### DIFF
--- a/tests/testthat/test-metrics.R
+++ b/tests/testthat/test-metrics.R
@@ -49,10 +49,10 @@ test_that("getAlpha computes accurate biodiversity metrics", {
   inv_expected <- vegan::diversity(data[, -1L], "inv")
 
   # Compare computed values with expected values
-  expect_equal(result$Shannon, shannon_expected, ignore_attr = FALSE)
-  expect_equal(result$expShannon, exp(shannon_expected), ignore_attr = FALSE)
-  expect_equal(result$Simpson, simpson_expected, ignore_attr = FALSE)
-  expect_equal(result$invSimpson, inv_expected, ignore_attr = FALSE)
+  expect_equal(result$Shannon, shannon_expected, ignore_attr = TRUE)
+  expect_equal(result$expShannon, exp(shannon_expected), ignore_attr = TRUE)
+  expect_equal(result$Simpson, simpson_expected, ignore_attr = TRUE)
+  expect_equal(result$invSimpson, inv_expected, ignore_attr = TRUE)
 })
 
 test_that("getAlpha works consistently", {


### PR DESCRIPTION
Vegan `diversity()` could drop names with tibbles. This was regarded as a bug in vegan and fixed in 2.8-0. BioTIMEr `test-metrics.R` failed because it tested that `diversity` results do not have site names. There were no differences in diversity results, only in names.

This is a better fix than 0b6d4f7 to skip CRAN tests which still gives error on github reverse dependency tests (and may give an error in CRAN reverse dependency tests).